### PR TITLE
Update code to use data folder and clear cache

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,6 +7,9 @@
     * `python3 -m venv venv`
     * `source venv/bin/activate`
 2. Install requirements `pip install -r requirements.txt` 
+3. Sign up for Hugging Face and generate auth token (https://huggingface.co/docs/hub/security-tokens)
+4. Request access to stable diffusion model https://huggingface.co/CompVis/stable-diffusion-v1-4
+5. Input access token to `access_token` in `server.py` and `stable-diffusion.py`
 
 ## Playground
 
@@ -16,4 +19,4 @@
 ## Server
 
 1. run `venv/bin/python server.py`
-2. endpoint available at `<ipaddress>:port/stable-diffusion/?prompt=<prompt>` 
+2. endpoint available at `<ipaddress>:port/stable-diffusion?prompt=<prompt>` 

--- a/stable-diffusion.py
+++ b/stable-diffusion.py
@@ -1,6 +1,9 @@
 from torch import autocast
 from diffusers import StableDiffusionPipeline, LMSDiscreteScheduler
 from IPython.display import Image
+import os
+
+access_token = "enter access token"
 
 # this will substitute the default PNDM scheduler for K-LMS  
 lms = LMSDiscreteScheduler(
@@ -12,13 +15,16 @@ lms = LMSDiscreteScheduler(
 pipe = StableDiffusionPipeline.from_pretrained(
     "CompVis/stable-diffusion-v1-4", 
     scheduler=lms,
-    use_auth_token=True
+    use_auth_token=access_token
 ).to("cuda")
 
 prompt = "a photo of an astronaut riding a horse on mars"
-file_name = "astronaut_rides_horse.png"
+file_name = os.path.join(root_dir(), "data", "astronaut_rides_horse.png")
 
 with autocast("cuda"):
     image = pipe(prompt)["sample"][0]  
+    image.save(file_name)
     
-image.save(file_name)
+torch.cuda.empty_cache()
+def root_dir():
+    return os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Code updates to:

- include steps to create auth_token and input to .py files.
- save image in data subfolder of running file. 
- updated to clear cache after image saved which released about 3gb of gpu memory on a 1080ti.